### PR TITLE
Implement additional screens

### DIFF
--- a/T-Trips/T-Trips/MVVM/Main/CreateTrip/CreateTripView.swift
+++ b/T-Trips/T-Trips/MVVM/Main/CreateTrip/CreateTripView.swift
@@ -1,0 +1,120 @@
+import UIKit
+import SnapKit
+
+final class CreateTripView: UIView {
+    private let textFieldFactory = TextFieldFactory()
+    private let buttonFactory = ButtonFactory()
+
+    public private(set) lazy var titleField: CustomTextField = {
+        let model = TextFieldModel(placeholder: "Название", state: .name)
+        return textFieldFactory.makeTextField(with: model)
+    }()
+
+    public private(set) lazy var startDateField: CustomTextField = {
+        let model = TextFieldModel(placeholder: "Дата начала", state: .picker)
+        let field = textFieldFactory.makeTextField(with: model)
+        field.inputView = startPicker
+        field.inputAccessoryView = accessoryToolbar
+        return field
+    }()
+
+    public private(set) lazy var endDateField: CustomTextField = {
+        let model = TextFieldModel(placeholder: "Дата конца", state: .picker)
+        let field = textFieldFactory.makeTextField(with: model)
+        field.inputView = endPicker
+        field.inputAccessoryView = accessoryToolbar
+        return field
+    }()
+
+    public private(set) lazy var budgetField: CustomTextField = {
+        let model = TextFieldModel(placeholder: "Бюджет", state: .money)
+        let field = textFieldFactory.makeTextField(with: model)
+        field.keyboardType = .decimalPad
+        field.inputAccessoryView = accessoryToolbar
+        return field
+    }()
+
+    public private(set) lazy var participantsField: CustomTextField = {
+        let model = TextFieldModel(placeholder: "Выберите участников", state: .picker)
+        let field = textFieldFactory.makeTextField(with: model)
+        field.inputView = participantsPicker
+        field.inputAccessoryView = accessoryToolbar
+        return field
+    }()
+
+    public private(set) var descriptionView: UITextView = {
+        let tv = UITextView()
+        tv.layer.borderWidth = 0.5
+        tv.layer.cornerRadius = 12
+        tv.layer.borderColor = UIColor.lightGray.cgColor
+        tv.font = .systemFont(ofSize: 16)
+        return tv
+    }()
+
+    public private(set) lazy var createButton: CustomButton = {
+        let button = CustomButton()
+        let model = buttonFactory.makeConfiguration(title: "Создать", state: .primary, isEnabled: false, action: nil)
+        button.configure(with: model)
+        return button
+    }()
+
+    let startPicker = UIDatePicker()
+    let endPicker = UIDatePicker()
+    let participantsPicker = UIPickerView()
+
+    private lazy var accessoryToolbar: UIToolbar = {
+        let toolbar = UIToolbar()
+        toolbar.sizeToFit()
+        let flex = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        let done = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(dismissInput))
+        toolbar.setItems([flex, done], animated: false)
+        return toolbar
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .systemBackground
+        [titleField, startDateField, endDateField, budgetField, participantsField, descriptionView, createButton].forEach(addSubview)
+        setupConstraints()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+
+    private func setupConstraints() {
+        titleField.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide).offset(24)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(50)
+        }
+        startDateField.snp.makeConstraints { make in
+            make.top.equalTo(titleField.snp.bottom).offset(16)
+            make.leading.trailing.height.equalTo(titleField)
+        }
+        endDateField.snp.makeConstraints { make in
+            make.top.equalTo(startDateField.snp.bottom).offset(16)
+            make.leading.trailing.height.equalTo(titleField)
+        }
+        budgetField.snp.makeConstraints { make in
+            make.top.equalTo(endDateField.snp.bottom).offset(16)
+            make.leading.trailing.height.equalTo(titleField)
+        }
+        participantsField.snp.makeConstraints { make in
+            make.top.equalTo(budgetField.snp.bottom).offset(16)
+            make.leading.trailing.height.equalTo(titleField)
+        }
+        descriptionView.snp.makeConstraints { make in
+            make.top.equalTo(participantsField.snp.bottom).offset(16)
+            make.leading.trailing.equalTo(titleField)
+            make.height.equalTo(100)
+        }
+        createButton.snp.makeConstraints { make in
+            make.top.equalTo(descriptionView.snp.bottom).offset(24)
+            make.leading.trailing.equalTo(titleField)
+            make.height.equalTo(50)
+        }
+    }
+
+    @objc private func dismissInput() { endEditing(true) }
+}

--- a/T-Trips/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
+++ b/T-Trips/T-Trips/MVVM/Main/CreateTrip/CreateTripViewController.swift
@@ -1,0 +1,65 @@
+import UIKit
+import Combine
+
+final class CreateTripViewController: UIViewController {
+    private let createView = CreateTripView()
+    private let viewModel = CreateTripViewModel()
+    private var cancellables = Set<AnyCancellable>()
+    private let users = MockData.users
+
+    override func loadView() { view = createView }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Создание поездки"
+        setupBindings()
+        setupPickers()
+        setupActions()
+    }
+
+    private func setupBindings() {
+        viewModel.$canCreate
+            .receive(on: RunLoop.main)
+            .sink { [weak self] enabled in self?.createView.createButton.isEnabled = enabled }
+            .store(in: &cancellables)
+    }
+
+    private func setupPickers() {
+        createView.startPicker.datePickerMode = .date
+        createView.endPicker.datePickerMode = .date
+        createView.participantsPicker.dataSource = self
+        createView.participantsPicker.delegate = self
+    }
+
+    private func setupActions() {
+        createView.titleField.addAction(UIAction { [weak self] _ in
+            self?.viewModel.title = self?.createView.titleField.text ?? ""
+        }, for: .editingChanged)
+        createView.budgetField.addAction(UIAction { [weak self] _ in
+            self?.viewModel.budget = self?.createView.budgetField.text ?? ""
+        }, for: .editingChanged)
+        createView.startPicker.addTarget(self, action: #selector(startChanged(_:)), for: .valueChanged)
+        createView.endPicker.addTarget(self, action: #selector(endChanged(_:)), for: .valueChanged)
+        createView.createButton.addAction(UIAction { [weak self] _ in self?.viewModel.create() }, for: .touchUpInside)
+
+        viewModel.onCreate = { [weak self] trip in
+            self?.navigationController?.popViewController(animated: true)
+        }
+    }
+
+    @objc private func startChanged(_ picker: UIDatePicker) { viewModel.startDate = picker.date }
+    @objc private func endChanged(_ picker: UIDatePicker) { viewModel.endDate = picker.date }
+}
+
+extension CreateTripViewController: UIPickerViewDataSource, UIPickerViewDelegate {
+    func numberOfComponents(in pickerView: UIPickerView) -> Int { 1 }
+    func pickerView(_ pickerView: UIPickerView, numberOfRowsInComponent component: Int) -> Int { users.count }
+    func pickerView(_ pickerView: UIPickerView, titleForRow row: Int, forComponent component: Int) -> String? {
+        let u = users[row]; return "\(u.firstName) \(u.lastName)"
+    }
+    func pickerView(_ pickerView: UIPickerView, didSelectRow row: Int, inComponent component: Int) {
+        let u = users[row]
+        viewModel.participants = [u]
+        createView.participantsField.text = "\(u.firstName) \(u.lastName)"
+    }
+}

--- a/T-Trips/T-Trips/MVVM/Main/CreateTrip/CreateTripViewModel.swift
+++ b/T-Trips/T-Trips/MVVM/Main/CreateTrip/CreateTripViewModel.swift
@@ -1,0 +1,41 @@
+import Foundation
+import Combine
+
+final class CreateTripViewModel {
+    @Published var title: String = ""
+    @Published var startDate = Date()
+    @Published var endDate = Date()
+    @Published var budget: String = ""
+    @Published var participants: [User] = []
+    @Published var description: String = ""
+
+    @Published private(set) var canCreate = false
+
+    var onCreate: ((Trip) -> Void)?
+
+    private var cancellables = Set<AnyCancellable>()
+
+    init() {
+        Publishers.CombineLatest3($title, $budget, $participants)
+            .map { !$0.0.isEmpty && Double($0.1) != nil && !$0.2.isEmpty }
+            .receive(on: RunLoop.main)
+            .assign(to: \ .canCreate, on: self)
+            .store(in: &cancellables)
+    }
+
+    func create() {
+        guard let budget = Double(budget) else { return }
+        let trip = Trip(
+            id: Int64.random(in: 100...999),
+            adminId: 0,
+            title: title,
+            startDate: startDate,
+            endDate: endDate,
+            budget: budget,
+            description: description,
+            status: .planning,
+            participantIds: participants.map { $0.id }
+        )
+        onCreate?(trip)
+    }
+}

--- a/T-Trips/T-Trips/MVVM/Main/Debts/DebtDetailView.swift
+++ b/T-Trips/T-Trips/MVVM/Main/Debts/DebtDetailView.swift
@@ -1,0 +1,29 @@
+import UIKit
+import SnapKit
+
+final class DebtDetailView: UIView {
+    let infoLabel = UILabel()
+    let confirmButton: CustomButton = {
+        let btn = CustomButton()
+        let model = ButtonFactory().makeConfiguration(title: "Подтвердить", state: .primary, isEnabled: true, action: nil)
+        btn.configure(with: model)
+        return btn
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .systemBackground
+        [infoLabel, confirmButton].forEach(addSubview)
+        infoLabel.numberOfLines = 0
+        infoLabel.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide).offset(24)
+            make.leading.trailing.equalToSuperview().inset(20)
+        }
+        confirmButton.snp.makeConstraints { make in
+            make.top.equalTo(infoLabel.snp.bottom).offset(24)
+            make.leading.trailing.equalTo(infoLabel)
+            make.height.equalTo(50)
+        }
+    }
+    required init?(coder: NSCoder) { super.init(coder: coder) }
+}

--- a/T-Trips/T-Trips/MVVM/Main/Debts/DebtDetailViewController.swift
+++ b/T-Trips/T-Trips/MVVM/Main/Debts/DebtDetailViewController.swift
@@ -1,0 +1,30 @@
+import UIKit
+import Combine
+
+final class DebtDetailViewController: UIViewController {
+    private let detailView = DebtDetailView()
+    private let viewModel: DebtDetailViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    init(debt: Debt) {
+        self.viewModel = DebtDetailViewModel(debt: debt)
+        super.init(nibName: nil, bundle: nil)
+    }
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func loadView() { view = detailView }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Детали"
+        bind()
+        detailView.confirmButton.addAction(UIAction { [weak self] _ in self?.viewModel.onConfirm?() }, for: .touchUpInside)
+    }
+
+    private func bind() {
+        viewModel.$info
+            .receive(on: RunLoop.main)
+            .assign(to: \ .text, on: detailView.infoLabel)
+            .store(in: &cancellables)
+    }
+}

--- a/T-Trips/T-Trips/MVVM/Main/Debts/DebtDetailViewModel.swift
+++ b/T-Trips/T-Trips/MVVM/Main/Debts/DebtDetailViewModel.swift
@@ -1,0 +1,12 @@
+import Foundation
+import Combine
+
+final class DebtDetailViewModel {
+    @Published private(set) var info: String
+    var onConfirm: (() -> Void)?
+
+    init(debt: Debt) {
+        let from = MockData.users.first { $0.id == debt.fromUserId }
+        info = "\(from?.firstName ?? "") должен \(String(format: "%.2f ₽", debt.amount))"
+    }
+}

--- a/T-Trips/T-Trips/MVVM/Main/Debts/DebtsView.swift
+++ b/T-Trips/T-Trips/MVVM/Main/Debts/DebtsView.swift
@@ -1,0 +1,19 @@
+import UIKit
+import SnapKit
+
+final class DebtsView: UIView {
+    let tableView: UITableView = {
+        let tv = UITableView()
+        tv.register(CustomTableCell.self, forCellReuseIdentifier: CustomTableCell.reuseId)
+        return tv
+    }()
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .systemBackground
+        addSubview(tableView)
+        tableView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+    required init?(coder: NSCoder) { super.init(coder: coder) }
+}

--- a/T-Trips/T-Trips/MVVM/Main/Debts/DebtsViewController.swift
+++ b/T-Trips/T-Trips/MVVM/Main/Debts/DebtsViewController.swift
@@ -1,0 +1,35 @@
+import UIKit
+import Combine
+
+final class DebtsViewController: UIViewController {
+    private let debtsView = DebtsView()
+    private let viewModel: DebtsViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    init(tripId: Int64) {
+        self.viewModel = DebtsViewModel(tripId: tripId)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func loadView() { view = debtsView }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Долги"
+        debtsView.tableView.dataSource = self
+    }
+}
+
+extension DebtsViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int { viewModel.debts.count }
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: CustomTableCell.reuseId, for: indexPath) as! CustomTableCell
+        let debt = viewModel.debts[indexPath.row]
+        let from = MockData.users.first { $0.id == debt.fromUserId }
+        cell.textLabel?.text = "\(from?.firstName ?? "") \(from?.lastName ?? "")"
+        cell.detailTextLabel?.text = String(format: "%.2f ₽", debt.amount)
+        return cell
+    }
+}

--- a/T-Trips/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
+++ b/T-Trips/T-Trips/MVVM/Main/Debts/DebtsViewModel.swift
@@ -1,0 +1,10 @@
+import Foundation
+import Combine
+
+final class DebtsViewModel {
+    @Published private(set) var debts: [Debt] = []
+
+    init(tripId: Int64) {
+        debts = MockData.debts.filter { $0.tripId == tripId }
+    }
+}

--- a/T-Trips/T-Trips/MVVM/Main/Notifications/NotificationsView.swift
+++ b/T-Trips/T-Trips/MVVM/Main/Notifications/NotificationsView.swift
@@ -1,0 +1,21 @@
+import UIKit
+import SnapKit
+
+final class NotificationsView: UIView {
+    let tableView: UITableView = {
+        let tv = UITableView()
+        tv.register(CustomTableCell.self, forCellReuseIdentifier: CustomTableCell.reuseId)
+        return tv
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .systemBackground
+        addSubview(tableView)
+        tableView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+
+    required init?(coder: NSCoder) { super.init(coder: coder) }
+}

--- a/T-Trips/T-Trips/MVVM/Main/Notifications/NotificationsViewController.swift
+++ b/T-Trips/T-Trips/MVVM/Main/Notifications/NotificationsViewController.swift
@@ -1,0 +1,26 @@
+import UIKit
+import Combine
+
+final class NotificationsViewController: UIViewController {
+    private let notificationsView = NotificationsView()
+    private let viewModel = NotificationsViewModel()
+    private var cancellables = Set<AnyCancellable>()
+
+    override func loadView() { view = notificationsView }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Уведомления"
+        notificationsView.tableView.dataSource = self
+    }
+}
+
+extension NotificationsViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int { viewModel.notifications.count }
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: CustomTableCell.reuseId, for: indexPath) as! CustomTableCell
+        let n = viewModel.notifications[indexPath.row]
+        cell.textLabel?.text = n.message
+        return cell
+    }
+}

--- a/T-Trips/T-Trips/MVVM/Main/Notifications/NotificationsViewModel.swift
+++ b/T-Trips/T-Trips/MVVM/Main/Notifications/NotificationsViewModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+import Combine
+
+final class NotificationsViewModel {
+    @Published private(set) var notifications: [NotificationItem] = MockData.notifications
+}

--- a/T-Trips/T-Trips/MVVM/Main/Settings/SettingsView.swift
+++ b/T-Trips/T-Trips/MVVM/Main/Settings/SettingsView.swift
@@ -1,0 +1,13 @@
+import UIKit
+import SnapKit
+
+final class SettingsView: UIView {
+    let tableView = UITableView()
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .systemBackground
+        addSubview(tableView)
+        tableView.snp.makeConstraints { make in make.edges.equalToSuperview() }
+    }
+    required init?(coder: NSCoder) { super.init(coder: coder) }
+}

--- a/T-Trips/T-Trips/MVVM/Main/Settings/SettingsViewController.swift
+++ b/T-Trips/T-Trips/MVVM/Main/Settings/SettingsViewController.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+final class SettingsViewController: UIViewController {
+    private let settingsView = SettingsView()
+
+    override func loadView() { view = settingsView }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Настройки"
+    }
+}

--- a/T-Trips/T-Trips/MVVM/Main/TripDetail/TripDetailView.swift
+++ b/T-Trips/T-Trips/MVVM/Main/TripDetail/TripDetailView.swift
@@ -1,0 +1,48 @@
+import UIKit
+import SnapKit
+
+final class TripDetailView: UIView {
+    let titleLabel = UILabel()
+    let datesLabel = UILabel()
+    let budgetLabel = UILabel()
+    let participantsLabel = UILabel()
+    let descriptionLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .systemBackground
+        [titleLabel, datesLabel, budgetLabel, participantsLabel, descriptionLabel].forEach(addSubview)
+        setupConstraints()
+        titleLabel.font = .boldSystemFont(ofSize: 20)
+        titleLabel.numberOfLines = 0
+        datesLabel.numberOfLines = 0
+        budgetLabel.numberOfLines = 0
+        participantsLabel.numberOfLines = 0
+        descriptionLabel.numberOfLines = 0
+    }
+
+    required init?(coder: NSCoder) { super.init(coder: coder) }
+
+    private func setupConstraints() {
+        titleLabel.snp.makeConstraints { make in
+            make.top.equalTo(safeAreaLayoutGuide).offset(24)
+            make.leading.trailing.equalToSuperview().inset(20)
+        }
+        datesLabel.snp.makeConstraints { make in
+            make.top.equalTo(titleLabel.snp.bottom).offset(16)
+            make.leading.trailing.equalTo(titleLabel)
+        }
+        budgetLabel.snp.makeConstraints { make in
+            make.top.equalTo(datesLabel.snp.bottom).offset(16)
+            make.leading.trailing.equalTo(titleLabel)
+        }
+        participantsLabel.snp.makeConstraints { make in
+            make.top.equalTo(budgetLabel.snp.bottom).offset(16)
+            make.leading.trailing.equalTo(titleLabel)
+        }
+        descriptionLabel.snp.makeConstraints { make in
+            make.top.equalTo(participantsLabel.snp.bottom).offset(16)
+            make.leading.trailing.equalTo(titleLabel)
+        }
+    }
+}

--- a/T-Trips/T-Trips/MVVM/Main/TripDetail/TripDetailViewController.swift
+++ b/T-Trips/T-Trips/MVVM/Main/TripDetail/TripDetailViewController.swift
@@ -1,0 +1,46 @@
+import UIKit
+import Combine
+
+final class TripDetailViewController: UIViewController {
+    private let detailView = TripDetailView()
+    private let viewModel: TripDetailViewModel
+    private var cancellables = Set<AnyCancellable>()
+
+    init(trip: Trip, participants: [User]) {
+        self.viewModel = TripDetailViewModel(trip: trip, participants: participants)
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+    override func loadView() { view = detailView }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "Детали поездки"
+        bind()
+    }
+
+    private func bind() {
+        viewModel.$title
+            .receive(on: RunLoop.main)
+            .assign(to: \ .text, on: detailView.titleLabel)
+            .store(in: &cancellables)
+        viewModel.$datesText
+            .receive(on: RunLoop.main)
+            .assign(to: \ .text, on: detailView.datesLabel)
+            .store(in: &cancellables)
+        viewModel.$budgetText
+            .receive(on: RunLoop.main)
+            .assign(to: \ .text, on: detailView.budgetLabel)
+            .store(in: &cancellables)
+        viewModel.$participantsText
+            .receive(on: RunLoop.main)
+            .assign(to: \ .text, on: detailView.participantsLabel)
+            .store(in: &cancellables)
+        viewModel.$description
+            .receive(on: RunLoop.main)
+            .assign(to: \ .text, on: detailView.descriptionLabel)
+            .store(in: &cancellables)
+    }
+}

--- a/T-Trips/T-Trips/MVVM/Main/TripDetail/TripDetailViewModel.swift
+++ b/T-Trips/T-Trips/MVVM/Main/TripDetail/TripDetailViewModel.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Combine
+
+final class TripDetailViewModel {
+    @Published private(set) var title: String
+    @Published private(set) var datesText: String
+    @Published private(set) var budgetText: String
+    @Published private(set) var participantsText: String
+    @Published private(set) var description: String
+
+    init(trip: Trip, participants: [User]) {
+        title = trip.title
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        datesText = "\(formatter.string(from: trip.startDate)) - \(formatter.string(from: trip.endDate))"
+        budgetText = String(format: "%.2f ₽", trip.budget)
+        participantsText = participants.map { "\($0.firstName) \($0.lastName)" }.joined(separator: ", ")
+        self.description = trip.description ?? ""
+    }
+}

--- a/T-Trips/T-Trips/MVVM/Start/StartView.swift
+++ b/T-Trips/T-Trips/MVVM/Start/StartView.swift
@@ -1,0 +1,25 @@
+import UIKit
+import SnapKit
+
+final class StartView: UIView {
+    private let imageView: UIImageView = {
+        let image = UIImage(named: "shieldT")
+        let view = UIImageView(image: image)
+        view.contentMode = .scaleAspectFit
+        return view
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = .systemBackground
+        addSubview(imageView)
+        imageView.snp.makeConstraints { make in
+            make.center.equalToSuperview()
+            make.width.height.equalTo(200)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+}

--- a/T-Trips/T-Trips/MVVM/Start/StartViewController.swift
+++ b/T-Trips/T-Trips/MVVM/Start/StartViewController.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+final class StartViewController: UIViewController {
+    private let startView = StartView()
+
+    override func loadView() {
+        view = startView
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            let authVC = AuthViewController()
+            let nav = UINavigationController(rootViewController: authVC)
+            nav.navigationBar.prefersLargeTitles = true
+            if let window = UIApplication.shared.windows.first {
+                window.rootViewController = nav
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create splash screen
- scaffold create trip flow
- add trip detail display
- implement notifications, debts, and settings skeleton screens

## Testing
- `swift --version`


------
https://chatgpt.com/codex/tasks/task_e_6845d8d06364832ca2129938f725573c